### PR TITLE
feat: 이력서 저장 API 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ Thumbs.db
 
 # Local configuration
 application-local.properties
-application.yml
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ Thumbs.db
 
 # Local configuration
 application-local.properties
-application-local.yml
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/hiresense/HiresenseBackendApplication.java
+++ b/src/main/java/com/hiresense/HiresenseBackendApplication.java
@@ -2,12 +2,13 @@ package com.hiresense;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class HiresenseBackendApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(HiresenseBackendApplication.class, args);
     }
-
 }

--- a/src/main/java/com/hiresense/config/SwaggerConfig.java
+++ b/src/main/java/com/hiresense/config/SwaggerConfig.java
@@ -5,9 +5,20 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class SwaggerConfig {
+public class SwaggerConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .maxAge(3600);
+    }
 
     @Bean
     public OpenAPI openAPI() {

--- a/src/main/java/com/hiresense/config/SwaggerConfig.java
+++ b/src/main/java/com/hiresense/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.hiresense.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .components(new Components())
+            .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("Hiresense API")
+            .description("Hiresense API 명세서")
+            .version("1.0.0");
+    }
+}

--- a/src/main/java/com/hiresense/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/hiresense/global/entity/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package com.hiresense.global.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/hiresense/global/error/BusinessException.java
+++ b/src/main/java/com/hiresense/global/error/BusinessException.java
@@ -1,0 +1,14 @@
+package com.hiresense.global.error;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/hiresense/global/error/ErrorCode.java
+++ b/src/main/java/com/hiresense/global/error/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.hiresense.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 공통
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력 값입니다"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "허용되지 않은 요청 방식입니다"),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "요청한 데이터를 찾을 수 없습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "서버 오류가 발생했습니다"),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C005", "잘못된 타입의 값입니다"),
+
+    // 이력서
+    RESUME_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "이력서를 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/hiresense/global/error/ErrorResponse.java
+++ b/src/main/java/com/hiresense/global/error/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.hiresense.global.error;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+    private String message;
+    private String code;
+
+    private ErrorResponse(final ErrorCode code) {
+        this.message = code.getMessage();
+        this.code = code.getCode();
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+}

--- a/src/main/java/com/hiresense/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/hiresense/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.hiresense.global.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+        log.error("handleBusinessException", e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus().value()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleException", e);
+        final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/hiresense/global/error/exception/InvalidInputValueException.java
+++ b/src/main/java/com/hiresense/global/error/exception/InvalidInputValueException.java
@@ -1,0 +1,11 @@
+package com.hiresense.global.error.exception;
+
+import com.hiresense.global.error.BusinessException;
+import com.hiresense.global.error.ErrorCode;
+
+public class InvalidInputValueException extends BusinessException {
+
+    public InvalidInputValueException() {
+        super(ErrorCode.INVALID_INPUT_VALUE);
+    }
+}

--- a/src/main/java/com/hiresense/global/error/exception/ResumeNotFoundException.java
+++ b/src/main/java/com/hiresense/global/error/exception/ResumeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hiresense.global.error.exception;
+
+import com.hiresense.global.error.BusinessException;
+import com.hiresense.global.error.ErrorCode;
+
+public class ResumeNotFoundException extends BusinessException {
+
+    public ResumeNotFoundException() {
+        super(ErrorCode.RESUME_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/hiresense/global/util/EnumConverter.java
+++ b/src/main/java/com/hiresense/global/util/EnumConverter.java
@@ -1,0 +1,17 @@
+package com.hiresense.global.util;
+
+import com.hiresense.global.error.exception.InvalidInputValueException;
+
+public class EnumConverter {
+
+    public static <T extends Enum<T>> T safeValueOf(Class<T> enumType, String name) {
+        if (name == null) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(enumType, name.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidInputValueException();
+        }
+    }
+}

--- a/src/main/java/com/hiresense/resume/controller/ResumeApiDocs.java
+++ b/src/main/java/com/hiresense/resume/controller/ResumeApiDocs.java
@@ -1,0 +1,62 @@
+package com.hiresense.resume.controller;
+
+import com.hiresense.global.error.ErrorResponse;
+import com.hiresense.resume.dto.request.ResumeRequest;
+import com.hiresense.resume.dto.request.ResumeUpdateRequest;
+import com.hiresense.resume.dto.response.ResumeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Resume", description = "이력서 API")
+public interface ResumeApiDocs {
+
+    @Operation(summary = "이력서 생성", description = "이력서를 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "이력서 생성 성공",
+            content = @Content(schema = @Schema(implementation = ResumeResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ResumeResponse> createResume(@RequestBody ResumeRequest request);
+
+    @Operation(summary = "이력서 수정", description = "이력서의 일부 정보를 수정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "이력서 수정 성공"),
+        @ApiResponse(responseCode = "404", description = "이력서를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> updateResume(@PathVariable Long id, @RequestBody ResumeUpdateRequest request);
+
+    @Operation(summary = "이력서 단건 조회", description = "이력서 한 건을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "이력서 조회 성공",
+            content = @Content(schema = @Schema(implementation = ResumeResponse.class))),
+        @ApiResponse(responseCode = "404", description = "이력서를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<ResumeResponse> getResumeById(@PathVariable Long id);
+
+    @Operation(summary = "이력서 전체 조회", description = "모든 이력서를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "이력서 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = List.class)))
+    })
+    ResponseEntity<List<ResumeResponse>> getAllResumes();
+
+    @Operation(summary = "이력서 삭제", description = "이력서를 삭제합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "이력서 삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "이력서를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> deleteResume(@PathVariable Long id);
+}

--- a/src/main/java/com/hiresense/resume/controller/ResumeController.java
+++ b/src/main/java/com/hiresense/resume/controller/ResumeController.java
@@ -1,0 +1,52 @@
+package com.hiresense.resume.controller;
+
+import com.hiresense.resume.dto.request.ResumeRequest;
+import com.hiresense.resume.dto.request.ResumeUpdateRequest;
+import com.hiresense.resume.dto.response.ResumeResponse;
+import com.hiresense.resume.service.ResumeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/resumes")
+public class ResumeController implements ResumeApiDocs {
+
+    private final ResumeService resumeService;
+
+    @PostMapping
+    public ResponseEntity<ResumeResponse> createResume(@Valid @RequestBody ResumeRequest request) {
+        ResumeResponse response = resumeService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/resumes/" + response.id())).body(response);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateResume(@PathVariable Long id,
+                                             @Valid @RequestBody ResumeUpdateRequest request) {
+        resumeService.update(id, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ResumeResponse> getResumeById(@PathVariable Long id) {
+        ResumeResponse response = resumeService.findById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ResumeResponse>> getAllResumes() {
+        List<ResumeResponse> responses = resumeService.findAll();
+        return ResponseEntity.ok(responses);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteResume(@PathVariable Long id) {
+        resumeService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/hiresense/resume/domain/AcademicRecord.java
+++ b/src/main/java/com/hiresense/resume/domain/AcademicRecord.java
@@ -1,0 +1,40 @@
+package com.hiresense.resume.domain;
+
+import com.hiresense.resume.domain.enums.AcademicStatus;
+import com.hiresense.resume.dto.request.AcademicRecordUpdateRequest;
+import com.hiresense.global.util.EnumConverter;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AcademicRecord {
+
+    private String schoolName;
+    private String period;
+
+    @Enumerated(EnumType.STRING)
+    private AcademicStatus status;
+
+    private Double gpa;
+    private String major;
+
+    public AcademicRecord updateFrom(AcademicRecordUpdateRequest request) {
+        String updatedSchoolName = Optional.ofNullable(request.schoolName()).orElse(this.schoolName);
+        String updatedPeriod = Optional.ofNullable(request.period()).orElse(this.period);
+        AcademicStatus updatedStatus = Optional.ofNullable(request.status()).map(s -> EnumConverter.safeValueOf(AcademicStatus.class, s)).orElse(this.status);
+        Double updatedGpa = Optional.ofNullable(request.gpa()).orElse(this.gpa);
+        String updatedMajor = Optional.ofNullable(request.major()).orElse(this.major);
+
+        return new AcademicRecord(updatedSchoolName, updatedPeriod, updatedStatus, updatedGpa, updatedMajor);
+    }
+}

--- a/src/main/java/com/hiresense/resume/domain/JobPreference.java
+++ b/src/main/java/com/hiresense/resume/domain/JobPreference.java
@@ -1,0 +1,36 @@
+package com.hiresense.resume.domain;
+
+import com.hiresense.resume.domain.enums.ExperienceLevel;
+import com.hiresense.resume.dto.request.JobPreferenceUpdateRequest;
+import com.hiresense.global.util.EnumConverter;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class JobPreference {
+
+    private String desiredJob;
+
+    @Enumerated(EnumType.STRING)
+    private ExperienceLevel experienceLevel;
+
+    private String description;
+
+    public JobPreference updateFrom(JobPreferenceUpdateRequest request) {
+        String updatedDesiredJob = Optional.ofNullable(request.desiredJob()).orElse(this.desiredJob);
+        ExperienceLevel updatedExperienceLevel = Optional.ofNullable(request.experienceLevel()).map(s -> EnumConverter.safeValueOf(ExperienceLevel.class, s)).orElse(this.experienceLevel);
+        String updatedDescription = Optional.ofNullable(request.description()).orElse(this.description);
+
+        return new JobPreference(updatedDesiredJob, updatedExperienceLevel, updatedDescription);
+    }
+}

--- a/src/main/java/com/hiresense/resume/domain/Resume.java
+++ b/src/main/java/com/hiresense/resume/domain/Resume.java
@@ -1,0 +1,118 @@
+package com.hiresense.resume.domain;
+
+import com.hiresense.resume.domain.enums.AcademicStatus;
+import com.hiresense.resume.domain.enums.EmploymentType;
+import com.hiresense.resume.domain.enums.ExperienceLevel;
+import com.hiresense.resume.domain.enums.Gender;
+import com.hiresense.resume.dto.request.ResumeRequest;
+import com.hiresense.resume.dto.request.ResumeUpdateRequest;
+import com.hiresense.global.entity.BaseTimeEntity;
+import com.hiresense.global.util.EnumConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Resume extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    private String birthYear;
+    private String phone;
+    private String email;
+    private String homePhone;
+
+    @Embedded
+    private AcademicRecord academicRecord;
+
+    @Embedded
+    private JobPreference jobPreference;
+
+    private String desiredRegion;
+    private Integer desiredSalary;
+
+    @Embedded
+    private WorkCondition workCondition;
+
+    @Builder
+    public Resume(String name, String address, Gender gender, String birthYear, String phone, String email, String homePhone, AcademicRecord academicRecord, JobPreference jobPreference, String desiredRegion, Integer desiredSalary, WorkCondition workCondition) {
+        this.name = name;
+        this.address = address;
+        this.gender = gender;
+        this.birthYear = birthYear;
+        this.phone = phone;
+        this.email = email;
+        this.homePhone = homePhone;
+        this.academicRecord = academicRecord;
+        this.jobPreference = jobPreference;
+        this.desiredRegion = desiredRegion;
+        this.desiredSalary = desiredSalary;
+        this.workCondition = workCondition;
+    }
+
+    public static Resume createFrom(ResumeRequest request) {
+        return Resume.builder()
+            .name(request.name())
+            .address(request.address())
+            .gender(EnumConverter.safeValueOf(Gender.class, request.gender()))
+            .birthYear(request.birthYear())
+            .phone(request.phone())
+            .email(request.email())
+            .homePhone(request.homePhone())
+            .academicRecord(new AcademicRecord(
+                request.academicRecord().schoolName(),
+                request.academicRecord().period(),
+                EnumConverter.safeValueOf(AcademicStatus.class, request.academicRecord().status()),
+                request.academicRecord().gpa(),
+                request.academicRecord().major()
+            ))
+            .jobPreference(new JobPreference(
+                request.jobPreference().desiredJob(),
+                EnumConverter.safeValueOf(ExperienceLevel.class, request.jobPreference().experienceLevel()),
+                request.jobPreference().description()
+            ))
+            .desiredRegion(request.desiredRegion())
+            .desiredSalary(request.desiredSalary())
+            .workCondition(new WorkCondition(
+                EnumConverter.safeValueOf(EmploymentType.class, request.workCondition().employmentType()),
+                request.workCondition().desiredHours()
+            ))
+            .build();
+    }
+
+    public void updateFrom(ResumeUpdateRequest request) {
+        Optional.ofNullable(request.name()).ifPresent(value -> this.name = value);
+        Optional.ofNullable(request.address()).ifPresent(value -> this.address = value);
+        Optional.ofNullable(request.gender()).ifPresent(value -> this.gender = EnumConverter.safeValueOf(Gender.class, value));
+        Optional.ofNullable(request.birthYear()).ifPresent(value -> this.birthYear = value);
+        Optional.ofNullable(request.phone()).ifPresent(value -> this.phone = value);
+        Optional.ofNullable(request.email()).ifPresent(value -> this.email = value);
+        Optional.ofNullable(request.homePhone()).ifPresent(value -> this.homePhone = value);
+        Optional.ofNullable(request.desiredRegion()).ifPresent(value -> this.desiredRegion = value);
+        Optional.ofNullable(request.desiredSalary()).ifPresent(value -> this.desiredSalary = value);
+
+        if (request.academicRecord() != null) {
+            this.academicRecord = academicRecord.updateFrom(request.academicRecord());
+        }
+        if (request.jobPreference() != null) {
+            this.jobPreference = jobPreference.updateFrom(request.jobPreference());
+        }
+        if (request.workCondition() != null) {
+            this.workCondition = workCondition.updateFrom(request.workCondition());
+        }
+    }
+}

--- a/src/main/java/com/hiresense/resume/domain/WorkCondition.java
+++ b/src/main/java/com/hiresense/resume/domain/WorkCondition.java
@@ -1,0 +1,33 @@
+package com.hiresense.resume.domain;
+
+import com.hiresense.resume.domain.enums.EmploymentType;
+import com.hiresense.resume.dto.request.WorkConditionUpdateRequest;
+import com.hiresense.global.util.EnumConverter;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class WorkCondition {
+
+    @Enumerated(EnumType.STRING)
+    private EmploymentType employmentType;
+
+    private String desiredHours;
+
+    public WorkCondition updateFrom(WorkConditionUpdateRequest request) {
+        EmploymentType updatedEmploymentType = Optional.ofNullable(request.employmentType()).map(s -> EnumConverter.safeValueOf(EmploymentType.class, s)).orElse(this.employmentType);
+        String updatedDesiredHours = Optional.ofNullable(request.desiredHours()).orElse(this.desiredHours);
+
+        return new WorkCondition(updatedEmploymentType, updatedDesiredHours);
+    }
+}

--- a/src/main/java/com/hiresense/resume/domain/enums/AcademicStatus.java
+++ b/src/main/java/com/hiresense/resume/domain/enums/AcademicStatus.java
@@ -1,0 +1,5 @@
+package com.hiresense.resume.domain.enums;
+
+public enum AcademicStatus {
+    ATTENDING, GRADUATED, LEAVE_OF_ABSENCE
+}

--- a/src/main/java/com/hiresense/resume/domain/enums/EmploymentType.java
+++ b/src/main/java/com/hiresense/resume/domain/enums/EmploymentType.java
@@ -1,0 +1,5 @@
+package com.hiresense.resume.domain.enums;
+
+public enum EmploymentType {
+    FULL_TIME, PART_TIME, CONTRACT
+}

--- a/src/main/java/com/hiresense/resume/domain/enums/ExperienceLevel.java
+++ b/src/main/java/com/hiresense/resume/domain/enums/ExperienceLevel.java
@@ -1,0 +1,5 @@
+package com.hiresense.resume.domain.enums;
+
+public enum ExperienceLevel {
+    NEWCOMER, EXPERIENCED
+}

--- a/src/main/java/com/hiresense/resume/domain/enums/Gender.java
+++ b/src/main/java/com/hiresense/resume/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.hiresense.resume.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/hiresense/resume/dto/request/AcademicRecordRequest.java
+++ b/src/main/java/com/hiresense/resume/dto/request/AcademicRecordRequest.java
@@ -1,0 +1,15 @@
+package com.hiresense.resume.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AcademicRecordRequest(
+    @NotBlank(message = "학교명은 필수 입력값입니다.")
+    String schoolName,
+    @NotBlank(message = "재학 기간은 필수 입력값입니다.")
+    String period,
+    @NotBlank(message = "재학 상태는 필수 입력값입니다.")
+    String status,
+    Double gpa,
+    String major
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/request/AcademicRecordUpdateRequest.java
+++ b/src/main/java/com/hiresense/resume/dto/request/AcademicRecordUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.hiresense.resume.dto.request;
+
+public record AcademicRecordUpdateRequest(
+    String schoolName,
+    String period,
+    String status,
+    Double gpa,
+    String major
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/request/JobPreferenceRequest.java
+++ b/src/main/java/com/hiresense/resume/dto/request/JobPreferenceRequest.java
@@ -1,0 +1,11 @@
+package com.hiresense.resume.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record JobPreferenceRequest(
+    @NotBlank(message = "희망 직무는 필수 입력값입니다.")
+    String desiredJob,
+    String experienceLevel,
+    String description
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/request/JobPreferenceUpdateRequest.java
+++ b/src/main/java/com/hiresense/resume/dto/request/JobPreferenceUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.hiresense.resume.dto.request;
+
+public record JobPreferenceUpdateRequest(
+    String desiredJob,
+    String experienceLevel,
+    String description
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/request/ResumeRequest.java
+++ b/src/main/java/com/hiresense/resume/dto/request/ResumeRequest.java
@@ -1,0 +1,34 @@
+package com.hiresense.resume.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ResumeRequest(
+    @NotBlank(message = "이름은 필수 입력값입니다.")
+    String name,
+    @NotBlank(message = "주소는 필수 입력값입니다.")
+    String address,
+    @NotBlank(message = "성별은 필수 입력값입니다.")
+    String gender,
+    @NotBlank(message = "생년월일은 필수 입력값입니다.")
+    String birthYear,
+    @NotBlank(message = "연락처는 필수 입력값입니다.")
+    String phone,
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    String email,
+    String homePhone,
+    @Valid
+    @NotNull(message = "학력 정보는 필수 입력값입니다.")
+    AcademicRecordRequest academicRecord,
+    @Valid
+    @NotNull(message = "희망 직무 정보는 필수 입력값입니다.")
+    JobPreferenceRequest jobPreference,
+    String desiredRegion,
+    @NotNull(message = "희망 연봉은 필수 입력값입니다.")
+    Integer desiredSalary,
+    @Valid
+    @NotNull(message = "희망 근무 조건은 필수 입력값입니다.")
+    WorkConditionRequest workCondition
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/request/ResumeUpdateRequest.java
+++ b/src/main/java/com/hiresense/resume/dto/request/ResumeUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.hiresense.resume.dto.request;
+
+import jakarta.validation.Valid;
+
+public record ResumeUpdateRequest(
+    String name,
+    String address,
+    String gender,
+    String birthYear,
+    String phone,
+    String email,
+    String homePhone,
+    @Valid
+    AcademicRecordUpdateRequest academicRecord,
+    @Valid
+    JobPreferenceUpdateRequest jobPreference,
+    String desiredRegion,
+    Integer desiredSalary,
+    @Valid
+    WorkConditionUpdateRequest workCondition
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/request/WorkConditionRequest.java
+++ b/src/main/java/com/hiresense/resume/dto/request/WorkConditionRequest.java
@@ -1,0 +1,10 @@
+package com.hiresense.resume.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WorkConditionRequest(
+    @NotBlank(message = "고용 형태는 필수 입력값입니다.")
+    String employmentType,
+    String desiredHours
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/request/WorkConditionUpdateRequest.java
+++ b/src/main/java/com/hiresense/resume/dto/request/WorkConditionUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.hiresense.resume.dto.request;
+
+public record WorkConditionUpdateRequest(
+    String employmentType,
+    String desiredHours
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/response/AcademicRecordResponse.java
+++ b/src/main/java/com/hiresense/resume/dto/response/AcademicRecordResponse.java
@@ -1,0 +1,10 @@
+package com.hiresense.resume.dto.response;
+
+public record AcademicRecordResponse(
+    String schoolName,
+    String period,
+    String status,
+    Double gpa,
+    String major
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/response/JobPreferenceResponse.java
+++ b/src/main/java/com/hiresense/resume/dto/response/JobPreferenceResponse.java
@@ -1,0 +1,8 @@
+package com.hiresense.resume.dto.response;
+
+public record JobPreferenceResponse(
+    String desiredJob,
+    String experienceLevel,
+    String description
+) {
+}

--- a/src/main/java/com/hiresense/resume/dto/response/ResumeResponse.java
+++ b/src/main/java/com/hiresense/resume/dto/response/ResumeResponse.java
@@ -1,0 +1,56 @@
+package com.hiresense.resume.dto.response;
+
+import com.hiresense.resume.domain.Resume;
+
+import java.time.LocalDateTime;
+
+public record ResumeResponse(
+    Long id,
+    String name,
+    String address,
+    String gender,
+    String birthYear,
+    String phone,
+    String email,
+    String homePhone,
+    AcademicRecordResponse academicRecord,
+    JobPreferenceResponse jobPreference,
+    String desiredRegion,
+    Integer desiredSalary,
+    WorkConditionResponse workCondition,
+    LocalDateTime createdAt,
+    LocalDateTime modifiedAt
+) {
+    public static ResumeResponse from(Resume resume) {
+        return new ResumeResponse(
+            resume.getId(),
+            resume.getName(),
+            resume.getAddress(),
+            resume.getGender().name(),
+            resume.getBirthYear(),
+            resume.getPhone(),
+            resume.getEmail(),
+            resume.getHomePhone(),
+            new AcademicRecordResponse(
+                resume.getAcademicRecord().getSchoolName(),
+                resume.getAcademicRecord().getPeriod(),
+                resume.getAcademicRecord().getStatus().name(),
+                resume.getAcademicRecord().getGpa(),
+                resume.getAcademicRecord().getMajor()
+            ),
+            new JobPreferenceResponse(
+                resume.getJobPreference().getDesiredJob(),
+                resume.getJobPreference().getExperienceLevel().name(),
+                resume.getJobPreference().getDescription()
+            ),
+            resume.getDesiredRegion(),
+            resume.getDesiredSalary(),
+            new WorkConditionResponse(
+                resume.getWorkCondition().getEmploymentType().name(),
+                resume.getWorkCondition().getDesiredHours()
+            ),
+            resume.getCreatedAt(),
+            resume.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/hiresense/resume/dto/response/WorkConditionResponse.java
+++ b/src/main/java/com/hiresense/resume/dto/response/WorkConditionResponse.java
@@ -1,0 +1,7 @@
+package com.hiresense.resume.dto.response;
+
+public record WorkConditionResponse(
+    String employmentType,
+    String desiredHours
+) {
+}

--- a/src/main/java/com/hiresense/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/hiresense/resume/repository/ResumeRepository.java
@@ -1,0 +1,7 @@
+package com.hiresense.resume.repository;
+
+import com.hiresense.resume.domain.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/src/main/java/com/hiresense/resume/service/ResumeService.java
+++ b/src/main/java/com/hiresense/resume/service/ResumeService.java
@@ -1,0 +1,68 @@
+package com.hiresense.resume.service;
+
+import com.hiresense.global.error.exception.ResumeNotFoundException;
+import com.hiresense.resume.domain.Resume;
+import com.hiresense.resume.dto.request.ResumeRequest;
+import com.hiresense.resume.dto.request.ResumeUpdateRequest;
+import com.hiresense.resume.dto.response.ResumeResponse;
+import com.hiresense.resume.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResumeService {
+
+    private final ResumeRepository resumeRepository;
+
+    @Transactional
+    public ResumeResponse create(ResumeRequest request) {
+        log.info("이력서 생성을 시작합니다. name: {}", request.name());
+        Resume resume = Resume.createFrom(request);
+        Resume savedResume = resumeRepository.save(resume);
+        log.info("이력서 생성이 완료되었습니다. id: {}", savedResume.getId());
+        return ResumeResponse.from(savedResume);
+    }
+
+    @Transactional
+    public void update(Long id, ResumeUpdateRequest request) {
+        log.info("ID {} 이력서 수정을 시작합니다.", id);
+        Resume resume = resumeRepository.findById(id)
+            .orElseThrow(ResumeNotFoundException::new);
+        resume.updateFrom(request);
+        log.info("ID {} 이력서 수정이 완료되었습니다.", id);
+    }
+
+    public ResumeResponse findById(Long id) {
+        log.info("ID {} 이력서 조회를 시작합니다.", id);
+        Resume resume = resumeRepository.findById(id)
+            .orElseThrow(ResumeNotFoundException::new);
+        log.info("ID {} 이력서 조회가 완료되었습니다.", id);
+        return ResumeResponse.from(resume);
+    }
+
+    public List<ResumeResponse> findAll() {
+        log.info("모든 이력서 조회를 시작합니다.");
+        List<Resume> resumes = resumeRepository.findAll();
+        log.info("총 {}개의 이력서 조회가 완료되었습니다.", resumes.size());
+        return resumes.stream()
+            .map(ResumeResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        log.info("ID {} 이력서 삭제를 시작합니다.", id);
+        Resume resume = resumeRepository.findById(id)
+            .orElseThrow(ResumeNotFoundException::new);
+        resumeRepository.delete(resume);
+        log.info("ID {} 이력서 삭제가 완료되었습니다.", id);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,17 @@
 spring:
   profiles:
-    active: local
+    active: dev
 
-# --- Common settings for all profiles will go here ---
+  datasource:
+    url: jdbc:mysql://localhost:3306/hiresense?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update # In production, use 'validate' or 'none'
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
 작업 내용 

- 이력서(Resume) CRUD API를 구현
- 이력서 생성, 조회, 수정, 삭제 기능을 제공
- Springdoc(Swagger)을 이용해 API 문서를 자동화
- 원활한 프론트엔드 개발을 위해 CORS 설정을 추가
- 개발 환경(DB) 설정을 추가

관련 이슈
- Closes #1 

참고 사항
 - API Endpoint: `/api/v1/resumes`
 - Swagger UI: `/swagger-ui/index.html` 에서 API 명세를 확인
