### PR TITLE
feat: 채용공고 저장 API

### DIFF
--- a/src/main/java/com/hiresense/jobPosting/controller/JobPostingApiDocs.java
+++ b/src/main/java/com/hiresense/jobPosting/controller/JobPostingApiDocs.java
@@ -1,0 +1,62 @@
+package com.hiresense.jobPosting.controller;
+
+import com.hiresense.global.error.ErrorResponse;
+import com.hiresense.jobPosting.dto.request.JobPostingRequest;
+import com.hiresense.jobPosting.dto.request.JobPostingUpdateRequest;
+import com.hiresense.jobPosting.dto.response.JobPostingResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "JobPosting", description = "채용 공고 API")
+public interface JobPostingApiDocs {
+
+    @Operation(summary = "채용 공고 생성", description = "채용 공고를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "채용 공고 생성 성공",
+                    content = @Content(schema = @Schema(implementation = JobPostingResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<JobPostingResponse> createJobPosting(@RequestBody JobPostingRequest request);
+
+    @Operation(summary = "채용 공고 전체 조회", description = "모든 채용 공고를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "채용 공고 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = List.class)))
+    })
+    ResponseEntity<List<JobPostingResponse>> getAllJobPostings();
+
+    @Operation(summary = "채용 공고 단건 조회", description = "채용 공고 한 건을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "채용 공고 조회 성공",
+                    content = @Content(schema = @Schema(implementation = JobPostingResponse.class))),
+            @ApiResponse(responseCode = "404", description = "채용 공고를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<JobPostingResponse> getJobPostingById(@PathVariable Long id);
+
+    @Operation(summary = "채용 공고 수정", description = "채용 공고의 일부 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "채용 공고 수정 성공"),
+            @ApiResponse(responseCode = "404", description = "채용 공고를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> updateJobPosting(@PathVariable Long id, @RequestBody JobPostingUpdateRequest request);
+
+    @Operation(summary = "채용 공고 삭제", description = "채용 공고를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "채용 공고 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "채용 공고를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> deleteJobPosting(@PathVariable Long id);
+}

--- a/src/main/java/com/hiresense/jobPosting/controller/JobPostingController.java
+++ b/src/main/java/com/hiresense/jobPosting/controller/JobPostingController.java
@@ -1,0 +1,52 @@
+package com.hiresense.jobPosting.controller;
+
+import com.hiresense.jobPosting.dto.request.JobPostingRequest;
+import com.hiresense.jobPosting.dto.request.JobPostingUpdateRequest;
+import com.hiresense.jobPosting.dto.response.JobPostingResponse;
+import com.hiresense.jobPosting.service.JobPostingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/job-postings")
+@RequiredArgsConstructor
+public class JobPostingController implements JobPostingApiDocs {
+
+    private final JobPostingService jobPostingService;
+
+    @PostMapping
+    public ResponseEntity<JobPostingResponse> createJobPosting(@Valid @RequestBody JobPostingRequest request) {
+        JobPostingResponse response = jobPostingService.create(request);
+        return ResponseEntity.created(URI.create("/api/v1/job-postings/" + response.id())).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<JobPostingResponse>> getAllJobPostings() {
+        List<JobPostingResponse> responses = jobPostingService.findAll();
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<JobPostingResponse> getJobPostingById(@PathVariable Long id) {
+        JobPostingResponse response = jobPostingService.findById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateJobPosting(@PathVariable Long id,
+                                             @Valid @RequestBody JobPostingUpdateRequest request) {
+        jobPostingService.update(id, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteJobPosting(@PathVariable Long id) {
+        jobPostingService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/hiresense/jobPosting/domain/JobPosting.java
+++ b/src/main/java/com/hiresense/jobPosting/domain/JobPosting.java
@@ -1,0 +1,68 @@
+package com.hiresense.jobPosting.domain;
+
+import com.hiresense.global.entity.BaseTimeEntity;
+import com.hiresense.jobPosting.dto.request.JobPostingRequest;
+import com.hiresense.jobPosting.dto.request.JobPostingUpdateRequest;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JobPosting extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String companyName;
+    private String jobTitle;
+    private String workLocation;
+    private String recruitmentPeriod;
+    private String qualifications;
+    private String idealCandidate;
+    private String preferredQualifications;
+    private String jobDescription;
+
+    @Builder
+    private JobPosting(String companyName, String jobTitle, String workLocation, String recruitmentPeriod, String qualifications, String idealCandidate, String preferredQualifications, String jobDescription) {
+        this.companyName = companyName;
+        this.jobTitle = jobTitle;
+        this.workLocation = workLocation;
+        this.recruitmentPeriod = recruitmentPeriod;
+        this.qualifications = qualifications;
+        this.idealCandidate = idealCandidate;
+        this.preferredQualifications = preferredQualifications;
+        this.jobDescription = jobDescription;
+    }
+
+    public static JobPosting createJobPosting(JobPostingRequest request) {
+        return JobPosting.builder()
+                .companyName(request.companyName())
+                .jobTitle(request.jobTitle())
+                .workLocation(request.workLocation())
+                .recruitmentPeriod(request.recruitmentPeriod())
+                .qualifications(request.qualifications())
+                .idealCandidate(request.idealCandidate())
+                .preferredQualifications(request.preferredQualifications())
+                .jobDescription(request.jobDescription())
+                .build();
+    }
+
+    public void updateJobPosting(JobPostingUpdateRequest request) {
+        Optional.ofNullable(request.companyName()).ifPresent(name -> this.companyName = name);
+        Optional.ofNullable(request.jobTitle()).ifPresent(title -> this.jobTitle = title);
+        Optional.ofNullable(request.workLocation()).ifPresent(location -> this.workLocation = location);
+        Optional.ofNullable(request.recruitmentPeriod()).ifPresent(period -> this.recruitmentPeriod = period);
+        Optional.ofNullable(request.qualifications()).ifPresent(qualifications -> this.qualifications = qualifications);
+        Optional.ofNullable(request.idealCandidate()).ifPresent(candidate -> this.idealCandidate = candidate);
+        Optional.ofNullable(request.preferredQualifications()).ifPresent(preferred -> this.preferredQualifications = preferred);
+        Optional.ofNullable(request.jobDescription()).ifPresent(description -> this.jobDescription = description);
+    }
+}

--- a/src/main/java/com/hiresense/jobPosting/dto/request/JobPostingRequest.java
+++ b/src/main/java/com/hiresense/jobPosting/dto/request/JobPostingRequest.java
@@ -1,0 +1,23 @@
+package com.hiresense.jobPosting.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record JobPostingRequest(
+    @NotBlank(message = "회사명은 필수 입력값입니다.")
+    String companyName,
+    @NotBlank(message = "직무는 필수 입력값입니다.")
+    String jobTitle,
+    @NotBlank(message = "근무지는 필수 입력값입니다.")
+    String workLocation,
+    @NotBlank(message = "모집 기간은 필수 입력값입니다.")
+    String recruitmentPeriod,
+    @NotBlank(message = "자격 요건은 필수 입력값입니다.")
+    String qualifications,
+    @NotBlank(message = "인재상은 필수 입력값입니다.")
+    String idealCandidate,
+    @NotBlank(message = "우대사항은 필수 입력값입니다.")
+    String preferredQualifications,
+    @NotBlank(message = "주요 업무는 필수 입력값입니다.")
+    String jobDescription
+) {
+}

--- a/src/main/java/com/hiresense/jobPosting/dto/request/JobPostingUpdateRequest.java
+++ b/src/main/java/com/hiresense/jobPosting/dto/request/JobPostingUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.hiresense.jobPosting.dto.request;
+
+public record JobPostingUpdateRequest(
+    String companyName,
+    String jobTitle,
+    String workLocation,
+    String recruitmentPeriod,
+    String qualifications,
+    String idealCandidate,
+    String preferredQualifications,
+    String jobDescription
+){
+}

--- a/src/main/java/com/hiresense/jobPosting/dto/response/JobPostingResponse.java
+++ b/src/main/java/com/hiresense/jobPosting/dto/response/JobPostingResponse.java
@@ -1,0 +1,29 @@
+package com.hiresense.jobPosting.dto.response;
+
+import com.hiresense.jobPosting.domain.JobPosting;
+
+public record JobPostingResponse(
+    Long id,
+    String companyName,
+    String jobTitle,
+    String workLocation,
+    String recruitmentPeriod,
+    String qualifications,
+    String idealCandidate,
+    String preferredQualifications,
+    String jobDescription
+) {
+    public static JobPostingResponse from(JobPosting jobPosting) {
+        return new JobPostingResponse(
+            jobPosting.getId(),
+            jobPosting.getCompanyName(),
+            jobPosting.getJobTitle(),
+            jobPosting.getWorkLocation(),
+            jobPosting.getRecruitmentPeriod(),
+            jobPosting.getQualifications(),
+            jobPosting.getIdealCandidate(),
+            jobPosting.getPreferredQualifications(),
+            jobPosting.getJobDescription()
+        );
+    }
+}

--- a/src/main/java/com/hiresense/jobPosting/repository/JobPostingRepository.java
+++ b/src/main/java/com/hiresense/jobPosting/repository/JobPostingRepository.java
@@ -1,0 +1,7 @@
+package com.hiresense.jobPosting.repository;
+
+import com.hiresense.jobPosting.domain.JobPosting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
+}

--- a/src/main/java/com/hiresense/jobPosting/service/JobPostingService.java
+++ b/src/main/java/com/hiresense/jobPosting/service/JobPostingService.java
@@ -1,0 +1,67 @@
+package com.hiresense.jobPosting.service;
+
+import com.hiresense.global.error.exception.ResumeNotFoundException;
+import com.hiresense.jobPosting.domain.JobPosting;
+import com.hiresense.jobPosting.dto.request.JobPostingRequest;
+import com.hiresense.jobPosting.dto.request.JobPostingUpdateRequest;
+import com.hiresense.jobPosting.dto.response.JobPostingResponse;
+import com.hiresense.jobPosting.repository.JobPostingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JobPostingService {
+    private final JobPostingRepository jobPostingRepository;
+
+    @Transactional
+    public JobPostingResponse create(JobPostingRequest request) {
+        log.info("채용공고 생성을 시작합니다. companyName: {}", request.companyName());
+        JobPosting jobPosting = JobPosting.createJobPosting(request);
+        JobPosting savedJobPosting= jobPostingRepository.save(jobPosting);
+        log.info("채용공고 생성이 완료되었습니다. id: {}", savedJobPosting.getId());
+        return JobPostingResponse.from(savedJobPosting);
+    }
+
+    public JobPostingResponse findById(Long id) {
+        log.info("ID {} 이력서 조회를 시작합니다.", id);
+        JobPosting jobPosting = jobPostingRepository.findById(id)
+                .orElseThrow(ResumeNotFoundException::new);
+        log.info("ID {} 이력서 조회가 완료되었습니다.", id);
+        return JobPostingResponse.from(jobPosting);
+    }
+
+    public List<JobPostingResponse> findAll() {
+        log.info("모든 이력서 조회를 시작합니다.");
+        List<JobPosting> jobPostings = jobPostingRepository.findAll();
+        log.info("총 {}개의 이력서 조회가 완료되었습니다.", jobPostings.size());
+        return jobPostings.stream()
+                .map(JobPostingResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void update(Long id, JobPostingUpdateRequest request) {
+        log.info("ID {} 이력서 수정을 시작합니다.", id);
+        JobPosting jobPosting = jobPostingRepository.findById(id)
+                .orElseThrow(ResumeNotFoundException::new);
+        jobPosting.updateJobPosting(request);
+        log.info("ID {} 이력서 수정이 완료되었습니다.", id);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        log.info("ID {} 이력서 삭제를 시작합니다.", id);
+        JobPosting jobPosting = jobPostingRepository.findById(id)
+                .orElseThrow(ResumeNotFoundException::new);
+        jobPostingRepository.delete(jobPosting);
+        log.info("ID {} 이력서 삭제가 완료되었습니다.", id);
+    }
+}

--- a/src/main/java/com/hiresense/resume/domain/Resume.java
+++ b/src/main/java/com/hiresense/resume/domain/Resume.java
@@ -49,7 +49,7 @@ public class Resume extends BaseTimeEntity {
     private WorkCondition workCondition;
 
     @Builder
-    public Resume(String name, String address, Gender gender, String birthYear, String phone, String email, String homePhone, AcademicRecord academicRecord, JobPreference jobPreference, String desiredRegion, Integer desiredSalary, WorkCondition workCondition) {
+    private Resume(String name, String address, Gender gender, String birthYear, String phone, String email, String homePhone, AcademicRecord academicRecord, JobPreference jobPreference, String desiredRegion, Integer desiredSalary, WorkCondition workCondition) {
         this.name = name;
         this.address = address;
         this.gender = gender;


### PR DESCRIPTION
작업 내용
- 채용공고(Job-posting) CRUD API를 구현
- 채용공고 생성, 조회, 수정, 삭제 기능을 제공
- Springdoc(Swagger)을 이용해 API 문서를 자동화
- 생성자 private으로 변경

Closes https://github.com/HireSenseTeam/hiresense-backend/issues/4


